### PR TITLE
Update NuGet audit CVE handling

### DIFF
--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -20,19 +20,20 @@ jobs:
           global-json-file: global.json
       - name: .NET Restore
         id: restore
-        shell: bash        
+        shell: bash
         run: |
-          mkdir ${{ github.workspace }}/results
-          touch ${{ github.workspace }}/results/dotnetrestore.log
-          set +e +o pipefail
-          CVECOUNT=$(dotnet restore src | tee ${{ github.workspace }}/results/dotnetrestore.log | grep -c -e "NU190[1-4]")
-          set -e -o pipefail
-          while read -r line; do
-            echo "$line"
-          done < ${{ github.workspace }}/results/dotnetrestore.log
-          exit $CVECOUNT
-      - name: Upload results on failure
-        if: ${{ failure() }}
+          mkdir -p ${{ github.workspace }}/results
+
+          dotnet restore src > "${{ github.workspace }}/results/dotnetrestore.log" 2>&1 || true
+          cat "${{ github.workspace }}/results/dotnetrestore.log"
+
+          CVECOUNT=$(awk '/NU190[1-4]/ { count++ } END { print count + 0 }' "${{ github.workspace }}/results/dotnetrestore.log")
+
+          echo "cvecount=${CVECOUNT}" >> "$GITHUB_OUTPUT"
+
+          echo "Found $CVECOUNT CVEs"
+      - name: Upload results when CVEs detected
+        if: ${{ steps.restore.outputs.cvecount > 0 }}
         shell: bash
         working-directory: ./src
         run: |
@@ -44,8 +45,8 @@ jobs:
              -F "restoreDataFile=@${{ github.workspace }}/results/restoreData.json" \
              -H "x-functions-key: ${{ secrets.FUNCTIONS_AUTHKEY }}" \
              ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}
-      - name: Archive files on failure
-        if: ${{ failure() }}
+      - name: Archive files when CVEs detected
+        if: ${{ steps.restore.outputs.cvecount > 0 }}
         uses: actions/upload-artifact@v7
         with:
           name: files

--- a/docs/nuget-audit.md
+++ b/docs/nuget-audit.md
@@ -23,11 +23,11 @@ The workflow detects if `dotnet restore` reports any of the following warning co
 - NU1903
 - NU1904
 
-If so it will exit with a number equal to the number of warning codes detected (total, not distinct), causing it to fail the workflow if any are detected.
+If so it records a `cvecount` step output equal to the number of warning codes detected (total, not distinct). The follow-up upload and archive steps run when that output is greater than zero.
 
 ### Restore data file
 
-If the workflow has failed because [CVEs have been detected](#cve-detection-mechanism), the workflow gathers information for further processing by [Internal Automation](https://github.com/Particular/InternalAutomation):
+If [CVEs have been detected](#cve-detection-mechanism), the workflow gathers information for further processing by [Internal Automation](https://github.com/Particular/InternalAutomation):
 
 - The GitHub repository ID that called this shared workflow
 - The name of the repository branch that called this shared workflow


### PR DESCRIPTION
## Summary
- Replicate the sandboxed NuGet audit workflow behavior from InternalAutomationSandbox
- Capture dotnet restore output to a log, count NU1901-NU1904 warnings with awk, and expose the count as a cvecount step output
- Gate result upload and artifact archival on the cvecount output instead of the restore step failure state
- Update the NuGet audit documentation to describe the new CVE detection flow

## Validation
- Parsed .github/workflows/nuget-audit.yml with Ruby YAML
- Ran git diff --check with CRLF-aware whitespace settings