### PR TITLE
Exclude Microsoft.Extensions.Azure from package matches

### DIFF
--- a/renovate/global-config.json5
+++ b/renovate/global-config.json5
@@ -164,6 +164,7 @@
         "Microsoft.AspNetCore.**",
         "Microsoft.Extensions.**",
         "System.**",
+        "!Microsoft.Extensions.Azure",
         "!System.IdentityModel.**",
         "!System.Management.Automation",
         "!System.Reactive"


### PR DESCRIPTION
This package has different version number than the other ones on the rule, so it should be excluded.