### PR TITLE
Add exclusion for Microsoft.Extensions.TimeProvider.Testing

### DIFF
--- a/renovate/global-config.json5
+++ b/renovate/global-config.json5
@@ -165,6 +165,7 @@
         "Microsoft.Extensions.**",
         "System.**",
         "!Microsoft.Extensions.Azure",
+        "!Microsoft.Extensions.TimeProvider.Testing",
         "!System.IdentityModel.**",
         "!System.Management.Automation",
         "!System.Reactive"


### PR DESCRIPTION
Exclude Microsoft.Extensions.TimeProvider.Testing from the .NET updates, as it seems to have an independent release cadence.