### PR TITLE
Separate one step in two

### DIFF
--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -38,13 +38,18 @@ jobs:
         working-directory: ./src
         run: |
           (dotnet list package --vulnerable --include-transitive --format json | jq '{"vulnerabilities": .}'; jq -s '{ "projectAssets": .}' */obj/project.assets.json) | jq -s add >> ${{ github.workspace }}/results/restoreData.json
-          curl -X POST \
+      - name: Upload results when CVEs detected
+        if: ${{ steps.restore.outputs.cvecount > 0 }}
+        shell: bash
+        working-directory: ./src
+        run: |
+           curl -X POST \
              -F "repository_id=${{ github.repository_id }}" \
              -F "branch=${{ github.ref_name }}" \
              -F "commit=${{ github.sha }}" \
              -F "restoreDataFile=@${{ github.workspace }}/results/restoreData.json" \
              -H "x-functions-key: ${{ secrets.FUNCTIONS_AUTHKEY }}" \
-             ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}
+             ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}  
       - name: Archive files when CVEs detected
         if: ${{ steps.restore.outputs.cvecount > 0 }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -32,7 +32,7 @@ jobs:
           echo "cvecount=${CVECOUNT}" >> "$GITHUB_OUTPUT"
 
           echo "Found $CVECOUNT CVEs"
-      - name: Upload results when CVEs detected
+      - name: Create results file when CVEs detected
         if: ${{ steps.restore.outputs.cvecount > 0 }}
         shell: bash
         working-directory: ./src
@@ -49,7 +49,7 @@ jobs:
              -F "commit=${{ github.sha }}" \
              -F "restoreDataFile=@${{ github.workspace }}/results/restoreData.json" \
              -H "x-functions-key: ${{ secrets.FUNCTIONS_AUTHKEY }}" \
-             ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}  
+             ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}
       - name: Archive files when CVEs detected
         if: ${{ steps.restore.outputs.cvecount > 0 }}
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The NuGet Audit workflow for ServiceInsight is failing for mysterious reasons. This PR separates the failing steps in two to be able to have more details of what is happening.