### PR TITLE
Handle excluded projects in NuGet audit

### DIFF
--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -24,20 +24,113 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/results
 
-          dotnet restore src > "${{ github.workspace }}/results/dotnetrestore.log" 2>&1 || true
+          set +e
+          dotnet restore src > "${{ github.workspace }}/results/dotnetrestore.log" 2>&1
+          RESTOREEXIT=$?
+          set -e
+
           cat "${{ github.workspace }}/results/dotnetrestore.log"
 
           CVECOUNT=$(awk '/NU190[1-4]/ { count++ } END { print count + 0 }' "${{ github.workspace }}/results/dotnetrestore.log")
 
           echo "cvecount=${CVECOUNT}" >> "$GITHUB_OUTPUT"
+          echo "restoreexit=${RESTOREEXIT}" >> "$GITHUB_OUTPUT"
 
-          echo "Found $CVECOUNT CVEs"
+          echo "Restore exited with code $RESTOREEXIT and found $CVECOUNT CVEs"
+
+          if (( RESTOREEXIT != 0 )); then
+            echo "::warning::dotnet restore exited with code $RESTOREEXIT. See dotnetrestore.log in the files artifact."
+          fi
       - name: Create results file when CVEs detected
         if: ${{ steps.restore.outputs.cvecount > 0 }}
         shell: bash
         working-directory: ./src
         run: |
-          (dotnet list package --vulnerable --include-transitive --format json | jq '{"vulnerabilities": .}'; jq -s '{ "projectAssets": .}' */obj/project.assets.json) | jq -s add >> ${{ github.workspace }}/results/restoreData.json
+          RESULTS_DIRECTORY="${{ github.workspace }}/results"
+          PACKAGE_LIST_FILE="$RESULTS_DIRECTORY/dotnet-package-list.json"
+          PACKAGE_LIST_LOG="$RESULTS_DIRECTORY/dotnet-package-list.log"
+          PROJECT_ASSETS_FILE="$RESULTS_DIRECTORY/project-assets.json"
+          RESTORE_DATA_FILE="$RESULTS_DIRECTORY/restoreData.json"
+
+          echo "::group::.NET and NuGet environment"
+          dotnet --info
+          dotnet nuget list source
+          echo "jq version: $(jq --version)"
+          echo "::endgroup::"
+
+          set +e
+          dotnet list package \
+            --vulnerable \
+            --include-transitive \
+            --format json \
+            --no-restore \
+            > "$PACKAGE_LIST_FILE" \
+            2> "$PACKAGE_LIST_LOG"
+          PACKAGE_LIST_EXIT=$?
+          set -e
+
+          echo "dotnet list package exited with code $PACKAGE_LIST_EXIT"
+
+          if [[ -s "$PACKAGE_LIST_LOG" ]]; then
+            echo "::group::dotnet list package stderr"
+            cat "$PACKAGE_LIST_LOG"
+            echo "::endgroup::"
+          fi
+
+          if ! jq -e 'type == "object" and (.projects | type == "array")' "$PACKAGE_LIST_FILE" > /dev/null; then
+            echo "::error::dotnet list package did not produce the expected JSON."
+            cat "$PACKAGE_LIST_FILE"
+            exit 1
+          fi
+
+          PROBLEM_COUNT=$(jq '(.problems // []) | length' "$PACKAGE_LIST_FILE")
+          MISSING_ASSETS_PROBLEM_COUNT=$(jq '
+            [
+              .problems[]?
+              | select(.text | contains("No assets file was found"))
+            ]
+            | length
+          ' "$PACKAGE_LIST_FILE")
+
+          if (( PROBLEM_COUNT > 0 )); then
+            echo "::group::dotnet list package problems"
+            jq -r '.problems[] | "\(.level): \(.project): \(.text)"' "$PACKAGE_LIST_FILE"
+            echo "::endgroup::"
+          fi
+
+          if (( PACKAGE_LIST_EXIT != 0 && (PROBLEM_COUNT == 0 || PROBLEM_COUNT != MISSING_ASSETS_PROBLEM_COUNT) )); then
+            echo "::error::dotnet list package exited with code $PACKAGE_LIST_EXIT and reported an unexpected problem."
+            exit "$PACKAGE_LIST_EXIT"
+          fi
+
+          if (( MISSING_ASSETS_PROBLEM_COUNT > 0 )); then
+            echo "::warning::dotnet list package skipped $MISSING_ASSETS_PROBLEM_COUNT project(s) that were excluded from restore; continuing with the restored projects."
+          fi
+
+          mapfile -d '' PROJECT_ASSET_FILES < <(find . -type f -path '*/obj/project.assets.json' -print0)
+
+          if (( ${#PROJECT_ASSET_FILES[@]} == 0 )); then
+            echo "::error::No project.assets.json files were found after restore."
+            exit 1
+          fi
+
+          echo "Found ${#PROJECT_ASSET_FILES[@]} project.assets.json files:"
+          printf '  %s\n' "${PROJECT_ASSET_FILES[@]}"
+
+          jq -s '{ "projectAssets": .}' "${PROJECT_ASSET_FILES[@]}" > "$PROJECT_ASSETS_FILE"
+          jq '{"vulnerabilities": del(.problems)}' "$PACKAGE_LIST_FILE" > "$RESULTS_DIRECTORY/vulnerabilities.json"
+          jq -s add \
+            "$RESULTS_DIRECTORY/vulnerabilities.json" \
+            "$PROJECT_ASSETS_FILE" \
+            > "$RESTORE_DATA_FILE"
+
+          jq -e '
+            (.vulnerabilities.projects | type == "array")
+            and (.projectAssets | type == "array")
+            and (.projectAssets | length > 0)
+          ' "$RESTORE_DATA_FILE" > /dev/null
+
+          echo "Created $RESTORE_DATA_FILE ($(wc -c < "$RESTORE_DATA_FILE") bytes)"
       - name: Upload results when CVEs detected
         if: ${{ steps.restore.outputs.cvecount > 0 }}
         shell: bash
@@ -51,7 +144,7 @@ jobs:
              -H "x-functions-key: ${{ secrets.FUNCTIONS_AUTHKEY }}" \
              ${{ secrets.PROCESSNUGETAUDITRESULTS_URL }}
       - name: Archive files when CVEs detected
-        if: ${{ steps.restore.outputs.cvecount > 0 }}
+        if: ${{ always() && steps.restore.outputs.cvecount > 0 }}
         uses: actions/upload-artifact@v7
         with:
           name: files


### PR DESCRIPTION
## Why

ServiceInsight includes `Setup.csproj` in its solution but intentionally omits its `Build.0` configuration entries, so `dotnet restore src` does not restore that project. The restore succeeds and creates assets for the other four projects.

`dotnet list package`, however, evaluates all five solution projects. It emits valid vulnerability JSON plus a `No assets file was found` problem for `Setup.csproj`, then exits with code 1. The existing compound pipeline runs under Bash `errexit` and `pipefail`, so that exit aborts collection before `restoreData.json` is assembled.

## What changed

- Capture and report restore and package-list exit codes instead of obscuring them in pipelines.
- Reuse the completed restore with `--no-restore`.
- Continue only when a nonzero package-list result contains valid JSON and all reported problems are missing assets for projects excluded from restore.
- Preserve unexpected failures and validate the generated payload.
- Discover restored `project.assets.json` files recursively instead of relying on a one-level glob.
- Archive raw package-list output, stderr, environment details, and intermediate JSON even when a later CVE-processing step fails.

## Validation

- Parsed the workflow as YAML and ran actionlint 1.7.12.
- Reproduced the ServiceInsight failure from a clean checkout in Ubuntu 24.04 with .NET SDK 10.0.302/runtime 10.0.10.
- Ran the updated collection step in that environment: it diagnosed the excluded `Setup.csproj`, created a valid payload containing five package-list projects and four restored asset files, and retained the raw missing-assets problem only in the diagnostic artifact.