### PR TITLE
Add setup-postgres-action to global config

### DIFF
--- a/renovate/global-config.json5
+++ b/renovate/global-config.json5
@@ -146,6 +146,7 @@
         "Particular/setup-cosmosdb-action",
         "Particular/setup-mongodb-action",
         "Particular/setup-oracle-action",
+        "Particular/setup-postgres-action",
         "Particular/setup-rabbitmq-action",
         "Particular/setup-ravendb-action",
         "Particular/sign-nuget-packages-action",


### PR DESCRIPTION
I think we missed this one when we created the config, so this PR will add it.