### PR TITLE
Added NUGET_PRIVATE_FEED_TOKEN environment variable for .NET Restore step.

### DIFF
--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -7,6 +7,8 @@ on:
         required: true
       PROCESSNUGETAUDITRESULTS_URL:
         required: true
+      FEEDZIO_PUBLISH_API_KEY:
+        required: false
 
 jobs:
   nuget-audit:

--- a/.github/workflows/nuget-audit.yml
+++ b/.github/workflows/nuget-audit.yml
@@ -21,6 +21,8 @@ jobs:
       - name: .NET Restore
         id: restore
         shell: bash
+        env:
+          NUGET_PRIVATE_FEED_TOKEN: ${{ secrets.FEEDZIO_PUBLISH_API_KEY }}
         run: |
           mkdir -p ${{ github.workspace }}/results
 


### PR DESCRIPTION
One of our repos needs this environment variable to be able to run `dotnet restore` but is currently silently failing.
With this change, the restore should be able to work without affecting any other repos as only one repo uses this variable.